### PR TITLE
fix: CLIN-222 rule builders + npe

### DIFF
--- a/src/main/java/bio/ferlab/clin/interceptors/ConsentServiceInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/ConsentServiceInterceptor.java
@@ -82,7 +82,7 @@ public class ConsentServiceInterceptor implements IConsentService {
         } else {
             if (resource instanceof Bundle) {
                 events.addAll(builder.addBundle((Bundle) resource).build());
-            } else {
+            } else if (requestDetails.getRestOperationType() != null) {
                 final AuditEvent.AuditEventAction action = getActionFromRestOperationType(requestDetails.getRestOperationType());
                 if (resource instanceof Resource) {
                     events.addAll(builder.addResource((Resource) resource, action).build());

--- a/src/test/java/bio/ferlab/clin/interceptors/BioAuthInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/BioAuthInterceptorTest.java
@@ -1,0 +1,135 @@
+package bio.ferlab.clin.interceptors;
+
+import bio.ferlab.clin.auth.RPTPermissionExtractor;
+import bio.ferlab.clin.auth.data.Permission;
+import bio.ferlab.clin.auth.data.UserPermissions;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Resource;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class BioAuthInterceptorTest {
+  
+  final RPTPermissionExtractor rptPermissionExtractor = Mockito.mock(RPTPermissionExtractor.class);
+  final BioAuthInterceptor bioAuthInterceptor = new BioAuthInterceptor(rptPermissionExtractor);
+  
+  private static final boolean testRule(IAuthRule rule, String operation, Class<? extends Resource> clazz) {
+    final String ruleStr = rule.toString();
+    return ruleStr.contains(operation.toUpperCase()) && ruleStr.contains(clazz.getSimpleName());
+  }
+
+  private static final boolean testRule(IAuthRule rule, String operation) {
+    final String ruleStr = rule.toString();
+    return ruleStr.contains(operation.toUpperCase());
+  }
+
+  @Nested
+  class BuildRuleList {
+    @Test
+    void lastRuleDenyAll() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of();
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+      
+      assertTrue(testRule(rules.get(rules.size() - 1), "ALL"));
+    }
+    
+    @Test
+    void crudPatient() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of(
+        new Permission(Patient.class, true, true, true, true)
+      );
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+      
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+      
+      assertTrue(testRule(rules.get(0), "READ", Patient.class));
+      assertTrue(testRule(rules.get(1), "WRITE", Patient.class));
+      assertTrue(testRule(rules.get(2), "CREATE", Patient.class));
+      assertTrue(testRule(rules.get(3), "DELETE", Patient.class));
+    }
+
+    @Test
+    void readPatient() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of(
+          new Permission(Patient.class, false, true, false, false)
+      );
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+
+      assertTrue(testRule(rules.get(0), "READ", Patient.class));
+    }
+    
+    @Test
+    void createPatient() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of(
+          new Permission(Patient.class, true, false, false, false)
+      );
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+
+      assertTrue(testRule(rules.get(0), "CREATE", Patient.class));
+    }
+
+    @Test
+    void writePatient() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of(
+          new Permission(Patient.class, false, false, true, false)
+      );
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+
+      assertTrue(testRule(rules.get(0), "WRITE", Patient.class));
+    }
+
+    @Test
+    void deletePatient() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of(
+          new Permission(Patient.class, false, false, false, true)
+      );
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+
+      assertTrue(testRule(rules.get(0), "DELETE", Patient.class));
+    }
+
+    @Test
+    void graphql() {
+      final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+      final List<Permission> perms = List.of();
+      final UserPermissions userPermissions = new UserPermissions(perms.toArray(Permission[]::new));
+
+      when(rptPermissionExtractor.extract(any())).thenReturn(userPermissions);
+      var rules = bioAuthInterceptor.buildRuleList(requestDetails);
+
+      assertTrue(testRule(rules.get(1), "GRAPHQL"));
+    }
+  }
+
+}


### PR DESCRIPTION
- [x] fix NPE 
- [x] separate the rule builders for create and write

**Explanation**: Create / write are exclusive in the same allow(), once your start to use create all the next rules will be create too even if specified as write.

**Solution**: Internally using allow(<name>) will create 2 separated rules set