### PR TITLE
fix: CLIN-1207 - allow null ramq mrn

### DIFF
--- a/src/main/java/bio/ferlab/clin/auth/RPTPermissionExtractor.java
+++ b/src/main/java/bio/ferlab/clin/auth/RPTPermissionExtractor.java
@@ -25,12 +25,8 @@ public class RPTPermissionExtractor {
         final var rpt = Helpers.extractAccessTokenFromBearer(bearer);
         final var response = this.client.introspectRpt(rpt);
         
-        if (Optional.ofNullable(response.getPermissions()).isEmpty()) {
-            throw new RptIntrospectionException("rpt token is required");
-        }
-    
-        if (!response.isActive()) {
-            throw new RptIntrospectionException("token is expired");
+        if (!response.isActive() || Optional.ofNullable(response.getPermissions()).isEmpty()) {
+            throw new RptIntrospectionException("not active rpt token");
         }
     
         final var builder = new UserPermissionsBuilder();

--- a/src/main/java/bio/ferlab/clin/interceptors/ImmutableMrnInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/ImmutableMrnInterceptor.java
@@ -62,7 +62,7 @@ public class ImmutableMrnInterceptor {
     if (isValidRequestAndResource(requestDetails, oldResource, newResource)) {
       final String oldMrn = getMrn((Patient)oldResource);
       final String newMrn = getMrn((Patient)newResource);
-      if (StringUtils.isNoneBlank(oldMrn, newMrn) && !oldMrn.equals(newMrn)) {
+      if (StringUtils.isNotBlank(oldMrn) && !oldMrn.equals(newMrn)) {
         throw new InvalidRequestException("Can't change the MRN (" + getObstructed(oldMrn) + ") of Patient/" + ((Patient) oldResource).getIdElement().getIdPart());
       }
     }

--- a/src/main/java/bio/ferlab/clin/interceptors/ImmutableRamqInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/ImmutableRamqInterceptor.java
@@ -63,7 +63,7 @@ public class ImmutableRamqInterceptor {
     if (isValidRequestAndResource(requestDetails, oldResource, newResource)) {
       final String oldRamq = getRamq((Person)oldResource);
       final String newRamq = getRamq((Person)newResource);
-      if (StringUtils.isNoneBlank(oldRamq, newRamq) && !oldRamq.equals(newRamq)) {
+      if (StringUtils.isNotBlank(oldRamq) && !oldRamq.equals(newRamq)) {
         throw new InvalidRequestException("Can't change the RAMQ (" + getObstructed(oldRamq) + ") of Person/" + ((Person) oldResource).getIdElement().getIdPart());
       }
     }

--- a/src/main/java/bio/ferlab/clin/validation/validators/nanuq/PatientValidator.java
+++ b/src/main/java/bio/ferlab/clin/validation/validators/nanuq/PatientValidator.java
@@ -27,7 +27,7 @@ public class PatientValidator extends SchemaValidator<Patient> {
 
   private boolean validateMRN(Patient patient) {
     Optional<Identifier> mrn = patient.getIdentifier().stream().filter(identifier -> MRN_CODE.equals(identifier.getType().getCodingFirstRep().getCode())).findFirst();
-    return mrn.map(Identifier::getValue).filter(m -> StringUtils.isNotBlank(m) && !ValidatorUtils.hasSpecialCharacters(m) && ValidatorUtils.isTrimmed(m)).isPresent();
+    return mrn.isEmpty() || mrn.map(Identifier::getValue).filter(m -> StringUtils.isNotBlank(m) && !ValidatorUtils.hasSpecialCharacters(m) && ValidatorUtils.isTrimmed(m)).isPresent();
   }
 
 }

--- a/src/main/java/bio/ferlab/clin/validation/validators/nanuq/PersonValidator.java
+++ b/src/main/java/bio/ferlab/clin/validation/validators/nanuq/PersonValidator.java
@@ -40,7 +40,7 @@ public class PersonValidator extends SchemaValidator<Person> {
 
   private boolean validateRAMQ(Person person) {
     Optional<Identifier> ramq = person.getIdentifier().stream().filter(identifier -> RAMQ_CODE.equals(identifier.getType().getCodingFirstRep().getCode())).findFirst();
-    return ramq.map(Identifier::getValue).filter(m -> StringUtils.isNotBlank(m) && ValidatorUtils.isValidRAMQ(m) && ValidatorUtils.isTrimmed(m)).isPresent();
+    return ramq.isEmpty() || ramq.map(Identifier::getValue).filter(m -> StringUtils.isNotBlank(m) && ValidatorUtils.isValidRAMQ(m) && ValidatorUtils.isTrimmed(m)).isPresent();
   }
 
   private boolean validateNames(Person person) {

--- a/src/main/java/ca/uhn/fhir/jpa/app/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/app/BaseJpaRestfulServer.java
@@ -202,11 +202,11 @@ public class BaseJpaRestfulServer extends RestfulServer {
          * This server tries to dynamically generate narratives
          */
         FhirContext ctx = getFhirContext();
-        INarrativeGenerator theNarrativeGenerator =
+        /*INarrativeGenerator theNarrativeGenerator =
                 appProperties.getNarrative_enabled() ?
                         new DefaultThymeleafNarrativeGenerator() :
                         new NullNarrativeGenerator();
-        ctx.setNarrativeGenerator(theNarrativeGenerator);
+        ctx.setNarrativeGenerator(theNarrativeGenerator);*/
 
         /*
          * Default to JSON and pretty printing

--- a/src/test/java/bio/ferlab/clin/auth/RPTPermissionExtractorTest.java
+++ b/src/test/java/bio/ferlab/clin/auth/RPTPermissionExtractorTest.java
@@ -46,10 +46,10 @@ public class RPTPermissionExtractorTest {
           RptIntrospectionException.class,
           () -> extractor.extract(requestDetails)
       );
-      assertTrue(ex.getMessage().equals("rpt token is required"));
+      assertTrue(ex.getMessage().equals("not active rpt token"));
     }
     @Test
-    void not_active() {
+    void not_active_token() {
       final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
       when(requestDetails.getHeader(any())).thenReturn("Bearer a.b.c");
       when(introspectionResponse.getPermissions()).thenReturn(new ArrayList<>());
@@ -59,7 +59,7 @@ public class RPTPermissionExtractorTest {
           RptIntrospectionException.class,
           () -> extractor.extract(requestDetails)
       );
-      assertTrue(ex.getMessage().equals("token is expired"));
+      assertTrue(ex.getMessage().equals("not active rpt token"));
     }
   }
 

--- a/src/test/java/bio/ferlab/clin/interceptors/ImmutableMrnInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/ImmutableMrnInterceptorTest.java
@@ -63,35 +63,33 @@ class ImmutableMrnInterceptorTest {
   }
   
   @Test
-  void update_error() {
-    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
-    
-    final Patient before = new Patient();
-    before.setId("1");
-    before.getIdentifierFirstRep().setValue("oldMrn").getType().getCodingFirstRep().setCode(MRN_CODE);
-    final Patient after = new Patient();
-    after.setId("1");
-    after.getIdentifierFirstRep().setValue("newMrn").getType().getCodingFirstRep().setCode(MRN_CODE);
-
-    Exception ex = Assertions.assertThrows(
-        InvalidRequestException.class,
-        () -> interceptor.updated(requestDetails, before, after)
-    );
-    assertEquals("Can't change the MRN (oldM...) of Patient/1", ex.getMessage());
+  void update() {
+    update("oldMrn",null, true);
+    update("oldMrn","newMrn", true);
+    update("oldMrn","oldMrn", false);
+    update(null,"newMrn", false);
   }
 
-  @Test
-  void update_ok() {
+  private void update(String oldValue, String newValue, boolean shouldThrowError) {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
 
     final Patient before = new Patient();
-    before.getIdentifierFirstRep().setValue("sameMrn").getType().getCodingFirstRep().setCode(MRN_CODE);
+    before.setId("1");
+    before.getIdentifierFirstRep().setValue(oldValue).getType().getCodingFirstRep().setCode(MRN_CODE);
     final Patient after = new Patient();
-    after.getIdentifierFirstRep().setValue("sameMrn").getType().getCodingFirstRep().setCode(MRN_CODE);
+    after.setId("1");
+    after.getIdentifierFirstRep().setValue(newValue).getType().getCodingFirstRep().setCode(MRN_CODE);
 
-    interceptor.updated(requestDetails, before, after);
+    if (shouldThrowError) {
+      Exception ex = Assertions.assertThrows(
+          InvalidRequestException.class,
+          () -> interceptor.updated(requestDetails, before, after)
+      );
+      assertEquals("Can't change the MRN (oldM...) of Patient/1", ex.getMessage());
+    }else {
+      interceptor.updated(requestDetails, before, after);
+    }
   }
 
 }

--- a/src/test/java/bio/ferlab/clin/interceptors/ImmutableMrnInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/ImmutableMrnInterceptorTest.java
@@ -6,9 +6,7 @@ import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Person;
-import org.hl7.fhir.r4.model.Specimen;
+import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -30,9 +28,10 @@ class ImmutableMrnInterceptorTest {
   void create_error() {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.POST);
-
+    
     final Patient patient = new Patient();
     patient.setId("1");
+    patient.setManagingOrganization(new Reference("Organization/org1"));
     patient.getIdentifierFirstRep().setValue("mrn").getType().getCodingFirstRep().setCode(MRN_CODE);
 
     final IBundleProvider bundle = Mockito.mock(IBundleProvider.class);
@@ -53,6 +52,7 @@ class ImmutableMrnInterceptorTest {
 
     final Patient patient = new Patient();
     patient.setId("1");
+    patient.setManagingOrganization(new Reference("Organization/org1"));
     patient.getIdentifierFirstRep().setValue("mrn").getType().getCodingFirstRep().setCode(MRN_CODE);
 
     final IBundleProvider bundle = Mockito.mock(IBundleProvider.class);

--- a/src/test/java/bio/ferlab/clin/interceptors/ImmutableRamqInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/ImmutableRamqInterceptorTest.java
@@ -63,35 +63,34 @@ class ImmutableRamqInterceptorTest {
   }
   
   @Test
-  void update_error() {
+  void update() {
+    update("oldRamq",null, true);
+    update("oldRamq","newRamq", true);
+    update("oldRamq","oldRamq", false);
+    update(null,"newRamq", false);
+  }
+  
+  private void update(String oldValue, String newValue, boolean shouldTrowError) {
+
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
-    
+
     final Person before = new Person();
     before.setId("1");
-    before.getIdentifierFirstRep().setValue("oldRamq").getType().getCodingFirstRep().setCode(RAMQ_CODE);
+    before.getIdentifierFirstRep().setValue(oldValue).getType().getCodingFirstRep().setCode(RAMQ_CODE);
     final Person after = new Person();
     after.setId("1");
-    after.getIdentifierFirstRep().setValue("newRamq").getType().getCodingFirstRep().setCode(RAMQ_CODE);
+    after.getIdentifierFirstRep().setValue(newValue).getType().getCodingFirstRep().setCode(RAMQ_CODE);
 
-    Exception ex = Assertions.assertThrows(
-        InvalidRequestException.class,
-        () -> interceptor.updated(requestDetails, before, after)
-    );
-    assertEquals("Can't change the RAMQ (oldR...) of Person/1", ex.getMessage());
-  }
-
-  @Test
-  void update_ok() {
-    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
-
-    final Person before = new Person();
-    before.getIdentifierFirstRep().setValue("sameRamq").getType().getCodingFirstRep().setCode(RAMQ_CODE);
-    final Person after = new Person();
-    after.getIdentifierFirstRep().setValue("sameRamq").getType().getCodingFirstRep().setCode(RAMQ_CODE);
-
-    interceptor.updated(requestDetails, before, after);
+    if (shouldTrowError) {
+      Exception ex = Assertions.assertThrows(
+          InvalidRequestException.class,
+          () -> interceptor.updated(requestDetails, before, after)
+      );
+      assertEquals("Can't change the RAMQ (oldR...) of Person/1", ex.getMessage());
+    } else {
+      interceptor.updated(requestDetails, before, after);
+    }
   }
 
 }

--- a/src/test/java/bio/ferlab/clin/validation/validators/nanuq/PatientValidatorTest.java
+++ b/src/test/java/bio/ferlab/clin/validation/validators/nanuq/PatientValidatorTest.java
@@ -1,8 +1,14 @@
 package bio.ferlab.clin.validation.validators.nanuq;
 
 import org.hl7.fhir.convertors.conv10_30.Patient10_30;
+import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Person;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -12,20 +18,31 @@ class PatientValidatorTest {
   
   @Test
   void validateResource() {
+    final Patient nullMrn = getValidPatient();
+    nullMrn.getIdentifierFirstRep().setValue(null);
+    assertFalse(validator.validate(nullMrn).isEmpty());
+
+    final Patient emptyMrn = getValidPatient();
+    emptyMrn.getIdentifierFirstRep().setValue("");
+    assertFalse(validator.validate(emptyMrn).isEmpty());
+
+    final Patient badFormatMrn = getValidPatient();
+    badFormatMrn.getIdentifierFirstRep().setValue(" foo");
+    assertFalse(validator.validate(badFormatMrn).isEmpty());
+
+    final Patient okMrn = getValidPatient();
+    okMrn.getIdentifierFirstRep().setValue("foo");
+    assertTrue(validator.validate(okMrn).isEmpty());
+
+    final Patient noMrn = getValidPatient();
+    noMrn.getIdentifier().clear();  // no MRN is OK
+    assertTrue(validator.validate(noMrn).isEmpty());
+  }
+
+  private Patient getValidPatient() {
     final Patient patient = new Patient();
-    patient.getIdentifierFirstRep().getType().getCodingFirstRep().setCode(PatientValidator.MRN_CODE);
-
-    patient.getIdentifierFirstRep().setValue(null);
-    assertFalse(validator.validate(patient).isEmpty());
-    
-    patient.getIdentifierFirstRep().setValue("");
-    assertFalse(validator.validate(patient).isEmpty());
-
-    patient.getIdentifierFirstRep().setValue(" foo");
-    assertFalse(validator.validate(patient).isEmpty());
-
-    patient.getIdentifierFirstRep().setValue("foo");
-    assertTrue(validator.validate(patient).isEmpty());
+    patient.getIdentifierFirstRep().setValue("CCCCCC").getType().getCodingFirstRep().setCode(PatientValidator.MRN_CODE);
+    return patient;
   }
 
 }

--- a/src/test/java/bio/ferlab/clin/validation/validators/nanuq/PersonValidatorTest.java
+++ b/src/test/java/bio/ferlab/clin/validation/validators/nanuq/PersonValidatorTest.java
@@ -28,6 +28,10 @@ class PersonValidatorTest {
     final Person badBirthDate = getValidPerson();
     badBirthDate.setBirthDate(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)));
     assertFalse(validator.validateResource(badBirthDate).isEmpty());
+
+    final Person noRamq = getValidPerson();
+    noRamq.getIdentifier().clear(); // no RAMQ is OK
+    assertTrue(validator.validateResource(noRamq).isEmpty());
   }
   
   private Person getValidPerson() {


### PR DESCRIPTION
- [x] Person/Patient can have a `null` ramq/mrn
- [x] `null` ramq/mrn can be changed later
- [x] Search for duplicated mrn should be done by organization
- [x] disable auto generated narrative