### PR TITLE
feat: CLIN-1455 restrict ldm access to resource Person

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,13 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.29</version>
+            <version>8.0.30</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.5</version>
+            <version>42.4.1</version>
         </dependency>
 
         <!-- Needed for Email subscriptions -->
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>moment</artifactId>
-            <version>2.29.3</version>
+            <version>2.29.4</version>
         </dependency>
 
         <!-- The following dependencies are only needed for automated unit tests, you do not neccesarily need them to run the example. -->
@@ -328,13 +328,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.3.20</version>
+            <version>5.3.21</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>5.3.20</version>
+            <version>5.3.21</version>
         </dependency>
         <!-- END https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751 -->
 
@@ -361,7 +361,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.29</version>
+            <version>1.31</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/bio/ferlab/clin/interceptors/SameRequestInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/SameRequestInterceptor.java
@@ -3,6 +3,7 @@ package bio.ferlab.clin.interceptors;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.api.server.IPreResourceAccessDetails;
 import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -20,10 +21,12 @@ public class SameRequestInterceptor {
 
   private final Map<RequestDetails, List<IBaseResource>> requests = new ConcurrentHashMap<>();
 
-  @Hook(Pointcut.STORAGE_PRESHOW_RESOURCES)
-  public void concatResources(IPreResourceShowDetails preResourceShowDetails, RequestDetails requestDetails) {
+  @Hook(Pointcut.STORAGE_PREACCESS_RESOURCES)
+  public void concatResources(IPreResourceAccessDetails preResourceShowDetails, RequestDetails requestDetails) {
     List<IBaseResource> resources = new ArrayList<>();
-    preResourceShowDetails.forEach(resources::add);
+    for (int i=0; i<preResourceShowDetails.size(); i++) {
+      resources.add(preResourceShowDetails.getResource(i));
+    }
     requests.computeIfAbsent(requestDetails, rd -> new ArrayList<>());
     requests.get(requestDetails).addAll(resources);
   }
@@ -32,7 +35,18 @@ public class SameRequestInterceptor {
   public void remove(RequestDetails requestDetails) {
     requests.remove(requestDetails);
   }
-  
+
+  /**
+   * Return list of resources associated to a RequestDetails.
+   * Resources from this list are read-only, modifying a field won't do anything.
+   * If you want to mask/edit data before the request ends then use STORAGE_PRESHOW_RESOURCES 
+   * (cf PrescriptionMaskingInterceptor)
+   * Be aware that resources listed in STORAGE_PRESHOW_RESOURCES aren't equals from JAVA object point of view 
+   * (cf FhirUtils.equals() to compare them)
+   * 
+   * @param requestDetails current RequestDetails
+   * @return read-only resources of the RequestDetails
+   */
   public List<IBaseResource> get(RequestDetails requestDetails) {
     return requests.get(requestDetails);
   }

--- a/src/main/java/bio/ferlab/clin/interceptors/SameRequestInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/SameRequestInterceptor.java
@@ -37,15 +37,10 @@ public class SameRequestInterceptor {
   }
 
   /**
-   * Return list of resources associated to a RequestDetails.
-   * Resources from this list are read-only, modifying a field won't do anything.
-   * If you want to mask/edit data before the request ends then use STORAGE_PRESHOW_RESOURCES 
-   * (cf PrescriptionMaskingInterceptor)
-   * Be aware that resources listed in STORAGE_PRESHOW_RESOURCES aren't equals from JAVA object point of view 
-   * (cf FhirUtils.equals() to compare them)
+   * Return list of immutable resources associated to a RequestDetails.
    * 
    * @param requestDetails current RequestDetails
-   * @return read-only resources of the RequestDetails
+   * @return immutable resources of the RequestDetails
    */
   public List<IBaseResource> get(RequestDetails requestDetails) {
     return requests.get(requestDetails);

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptor.java
@@ -70,7 +70,7 @@ public class MetaTagInterceptor {
       this.addTagCode(resource, metaTagResourceVisitor.extractEpCode(requestDetails, resource));
       this.addTagCode(resource, metaTagResourceVisitor.extractLdmCode(requestDetails, resource));
       // we could allow cross modify if needed with a custom config boolean, for now it's mandatory
-      if(!metaTagResourceAccess.canModifyResource(requestDetails, resource)) {
+      if(!metaTagResourceAccess.canSeeResource(requestDetails, resource)) {
         throw new ForbiddenOperationException("Resource belongs to another organization");
       }
     }

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
@@ -1,0 +1,76 @@
+package bio.ferlab.clin.interceptors.metatag;
+
+import bio.ferlab.clin.es.config.ResourceDaoConfiguration;
+import bio.ferlab.clin.interceptors.SameRequestInterceptor;
+import bio.ferlab.clin.utils.MaskingUtils;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import lombok.RequiredArgsConstructor;
+import org.hl7.fhir.instance.model.api.IAnyResource;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Person;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.LDM_TAG_PREFIX;
+import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.USER_ALL_TAGS;
+
+@Component
+@RequiredArgsConstructor
+public class MetaTagPerson {
+  
+  private final SameRequestInterceptor sameRequestInterceptor;
+  private final ResourceDaoConfiguration daoConfiguration;
+  
+  // custom implementation of canSeeResource for Person
+  public boolean canSeeResource(MetaTagResourceAccess metaTagResourceAccess, RequestDetails requestDetails, Person person) {
+    final List<String> userTags = metaTagResourceAccess.getUserTags(requestDetails);
+    if (!userTags.contains(USER_ALL_TAGS) && isOnlyLDM(userTags)) {  // restrict access only for LDMs, EP always see Person
+      final List<IBaseResource> resources = sameRequestInterceptor.get(requestDetails);
+      // only if not a prescription (cf PrescriptionMaskingInterceptor)
+      if (resources.contains(person) && !MaskingUtils.isValidPrescriptionRequest(resources)) {
+        // Person resources aren't tagged with EP, instead let's find out all related Patients
+        final List<Patient> patients = fetchPatients(person);
+        final List<ServiceRequest> serviceRequests = fetchServiceRequests(patients);
+
+        final Set<String> resourceTags = patients.stream().flatMap(p -> metaTagResourceAccess.getResourceTags(p).stream()).collect(Collectors.toSet());
+        resourceTags.addAll(serviceRequests.stream().flatMap(sr -> metaTagResourceAccess.getResourceTags(sr).stream()).collect(Collectors.toSet()));
+        // if user has no reasons to see this person data, mask them
+        return resourceTags.stream().anyMatch(userTags::contains);
+      }
+    }
+    return true;
+  }
+  
+  private boolean isOnlyLDM(List<String> userTags) {
+    return userTags.stream().allMatch(t -> t.startsWith(LDM_TAG_PREFIX));
+  }
+
+  private List<Patient> fetchPatients(Person person) {
+    final IBundleProvider results = daoConfiguration.personDAO.search(SearchParameterMap.newSynchronous()
+        .add(IAnyResource.SP_RES_ID, new TokenParam(person.getIdElement().getIdPart()))
+        .addInclude(Person.INCLUDE_PATIENT));
+    return results.isEmpty() ? List.of() : results.getAllResources().stream()
+        .filter(Patient.class::isInstance).map(Patient.class::cast).collect(Collectors.toList());
+  }
+
+  private List<ServiceRequest> fetchServiceRequests(List<Patient> patients) {
+    final List<ServiceRequest> serviceRequests = new ArrayList<>();
+    patients.forEach(patient -> {
+      final IBundleProvider results = daoConfiguration.serviceRequestDAO.search(SearchParameterMap.newSynchronous()
+          .add(ServiceRequest.SP_PATIENT, new ReferenceParam(patient.getIdElement().getIdPart())));
+      serviceRequests.addAll(results.isEmpty() ? List.of() :
+          results.getAllResources().stream().map(ServiceRequest.class::cast).collect(Collectors.toList()));
+    });
+    return serviceRequests;
+  }
+}

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.LDM_TAG_PREFIX;
-import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.USER_ALL_TAGS;
 
 @Component
 @RequiredArgsConstructor
@@ -34,7 +33,7 @@ public class MetaTagPerson {
   // custom implementation of canSeeResource for Person
   public boolean canSeeResource(MetaTagResourceAccess metaTagResourceAccess, RequestDetails requestDetails, Person person) {
     final List<String> userTags = metaTagResourceAccess.getUserTags(requestDetails);
-    if (!userTags.contains(USER_ALL_TAGS) && isOnlyLDM(userTags)) {  // restrict access only for LDMs, EP always see Person
+    if (isOnlyLDM(userTags)) {  // restrict access only for LDMs, EP always see Person
       final List<IBaseResource> resources = sameRequestInterceptor.get(requestDetails);
       // only if not a prescription (cf PrescriptionMaskingInterceptor)
       if (resources.contains(person) && !MaskingUtils.isValidPrescriptionRequest(resources)) {

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccess.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccess.java
@@ -35,6 +35,15 @@ public class MetaTagResourceAccess {
   
   private final BioProperties bioProperties;
   private final MetaTagPerson metaTagPerson;
+  private final PrescriptionMasking prescriptionMasking;
+  
+  public void preShow(RequestDetails requestDetails, IBaseResource resource) {
+    if (bioProperties.isTaggingEnabled()) {
+      if (resource instanceof Person) {
+        prescriptionMasking.preShow(this, (Person) resource, requestDetails);
+      }
+    }
+  }
 
   public boolean canSeeResource(RequestDetails requestDetails, IBaseResource resource) {
     if (bioProperties.isTaggingEnabled()) {

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/PrescriptionMasking.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/PrescriptionMasking.java
@@ -1,12 +1,8 @@
-package bio.ferlab.clin.interceptors;
+package bio.ferlab.clin.interceptors.metatag;
 
-import bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess;
+import bio.ferlab.clin.interceptors.SameRequestInterceptor;
 import bio.ferlab.clin.utils.FhirUtils;
 import bio.ferlab.clin.utils.MaskingUtils;
-import ca.uhn.fhir.interceptor.api.Hook;
-import ca.uhn.fhir.interceptor.api.Interceptor;
-import ca.uhn.fhir.interceptor.api.Pointcut;
-import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -14,36 +10,30 @@ import org.hl7.fhir.r4.model.*;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Optional;
 
 import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.USER_ALL_TAGS;
 
 @Component
-@Interceptor
 @RequiredArgsConstructor
-public class PrescriptionMaskingInterceptor {
+public class PrescriptionMasking {
   
   public static final String RESTRICTED_FIELD = "*****";
   
-  private final MetaTagResourceAccess metaTagResourceAccess;
   private final SameRequestInterceptor sameRequestInterceptor;
   
-  @Hook(Pointcut.STORAGE_PRESHOW_RESOURCES)
-  public void preShow(IPreResourceShowDetails preResourceShowDetails, RequestDetails requestDetails) {
+  public void preShow(MetaTagResourceAccess metaTagResourceAccess, Person personToShow, RequestDetails requestDetails) {
     final List<IBaseResource> resources = sameRequestInterceptor.get(requestDetails);
-    // extract the Person object, this one can be edited (the one in resources can not)
-    final Person personToShow = MaskingUtils.extractPerson(preResourceShowDetails);
     if (personToShow != null && MaskingUtils.isValidPrescriptionRequest(resources)) {
-      // this one can't be edited but at least should reference the same Person
+      // check if personToShow and personFromRequest are the same (because not same JAVA object)
       final Person personFromRequest = FhirUtils.extractAllOfType(resources, Person.class).get(0);
       if (FhirUtils.equals(personFromRequest, personToShow) && !MaskingUtils.isAlreadyMasked(personToShow)) {
         final List<String> userTags = metaTagResourceAccess.getUserTags(requestDetails);
-        maskSensitiveData(userTags, MaskingUtils.extractAnalysis(resources), personToShow);
+        maskSensitiveData(metaTagResourceAccess, userTags, MaskingUtils.extractAnalysis(resources), personToShow);
       }
     }
   }
   
-  private void maskSensitiveData(List<String> userTags, ServiceRequest sr, Person person) {
+  private void maskSensitiveData(MetaTagResourceAccess metaTagResourceAccess, List<String> userTags, ServiceRequest sr, Person person) {
     final List<String> resourceTags = metaTagResourceAccess.getResourceTags(sr);
     if (!userTags.contains(USER_ALL_TAGS) && resourceTags.stream().noneMatch(userTags::contains)) {
       person.setId(RESTRICTED_FIELD);

--- a/src/main/java/bio/ferlab/clin/utils/FhirUtils.java
+++ b/src/main/java/bio/ferlab/clin/utils/FhirUtils.java
@@ -1,0 +1,53 @@
+package bio.ferlab.clin.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Reference;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FhirUtils {
+  
+  private FhirUtils(){}
+  
+  public static String formatResource(IBaseResource resource) {
+    return String.format("%s/%s", resource.fhirType(), resource.getIdElement().getIdPart());
+  }
+
+  public static Reference toReference(IBaseResource resource) {
+    return new Reference(formatResource(resource));
+  }
+  
+  public static String extractId(String url) {
+    return extractId(new Reference(url));
+  }
+  
+  public static String extractId(Reference reference) {
+    if (reference != null) {
+      final String ref = reference.getReference();
+      if (StringUtils.isNotBlank(ref) && ref.contains("/")) {
+        return ref.split("/")[1];
+      }
+    }
+    return null;
+  }
+
+  public static <T extends IBaseResource> List<T> extractAllOfType(List<? extends IBaseResource> resources, Class<T> c) {
+    List<T> results = new ArrayList<>();
+    resources.forEach(res -> {
+      if (res != null && res.getClass().equals(c)) {
+        results.add((T)res);
+      } else if (res instanceof Bundle) {
+        ((Bundle) res).getEntry().stream().map(Bundle.BundleEntryComponent::getResource).filter(c::isInstance)
+            .forEach(r ->  results.add((T)r));
+      }
+    });
+    return results;
+  }
+
+  public static boolean equals(IBaseResource res1 , IBaseResource res2) {
+    return res1!=null && res2 != null && formatResource(res1).equals(formatResource(res2));
+  }
+}

--- a/src/main/java/bio/ferlab/clin/utils/MaskingUtils.java
+++ b/src/main/java/bio/ferlab/clin/utils/MaskingUtils.java
@@ -1,6 +1,7 @@
 package bio.ferlab.clin.utils;
 
 import bio.ferlab.clin.es.builder.nanuq.AbstractPrescriptionDataBuilder;
+import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
@@ -8,6 +9,8 @@ import org.hl7.fhir.r4.model.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static bio.ferlab.clin.interceptors.PrescriptionMaskingInterceptor.RESTRICTED_FIELD;
 
 public class MaskingUtils {
   
@@ -19,34 +22,42 @@ public class MaskingUtils {
   }
   
   public static boolean areLinked(ServiceRequest sr, Patient p) {
-    return Optional.ofNullable(sr).map(ServiceRequest::getSubject).map(MaskingUtils::extractId).stream()
+    return Optional.ofNullable(sr).map(ServiceRequest::getSubject).map(FhirUtils::extractId).stream()
         .anyMatch(id -> p != null && id.equals(p.getIdElement().getIdPart()));
   }
 
   public static boolean areLinked(Person pers, Patient patient) {
-    return pers != null && pers.getLink().stream().anyMatch(l -> patient != null && extractId(l.getTarget()).equals(patient.getIdElement().getIdPart()));
-  }
-  
-  public static <T extends IBaseResource> List<T> extractAllOfType(List<IBaseResource> resources, Class<T> c) {
-    List<T> results = new ArrayList<>();
-    resources.forEach(res -> {
-      if (res.getClass().equals(c)) {
-        results.add((T)res);
-      } else if (res instanceof Bundle) {
-        ((Bundle) res).getEntry().stream().map(Bundle.BundleEntryComponent::getResource).filter(c::isInstance)
-            .forEach(r ->  results.add((T)r));
-      }
-    });
-    return results;
+    return pers != null && pers.getLink().stream().anyMatch(l -> patient != null && FhirUtils.extractId(l.getTarget()).equals(patient.getIdElement().getIdPart()));
   }
 
-  public static String extractId(Reference reference) {
-    if (reference != null) {
-      final String ref = reference.getReference();
-      if (StringUtils.isNotBlank(ref) && ref.contains("/")) {
-        return ref.split("/")[1];
-      }
+  public static boolean isValidPrescriptionRequest(List<IBaseResource> resources) {
+    // the following algorithm detects if the current request is about displaying a Prescription
+    final ServiceRequest analysis = extractAnalysis(resources);
+    final List<Patient> patients = FhirUtils.extractAllOfType(resources, Patient.class);
+    final List<Person> persons = FhirUtils.extractAllOfType(resources, Person.class);
+    if (analysis != null && patients.size() == 1 && persons.size() == 1) {
+      Patient patient = patients.get(0);
+      Person pers = persons.get(0);
+      return MaskingUtils.areLinked(analysis, patient) && MaskingUtils.areLinked(pers, patient);
     }
-    return null;
+    return false;
   }
+  
+  public static Person extractPerson(IPreResourceShowDetails details) {
+    final List<IBaseResource> resources = new ArrayList<>();
+    if (details != null) {
+      details.forEach(resources::add);
+    }
+    final List<Person> persons = FhirUtils.extractAllOfType(resources, Person.class);
+    return persons.isEmpty() ? null : persons.get(0);
+  }
+  
+  public static ServiceRequest extractAnalysis(List<? extends IBaseResource> resources) {
+    return FhirUtils.extractAllOfType(resources, ServiceRequest.class).stream().filter(MaskingUtils::isAnalysis).findFirst().orElse(null);
+  }
+
+  public static boolean isAlreadyMasked(Person person) {
+    return Optional.ofNullable(person).map(Person::getId).stream().anyMatch(id -> id.equals(RESTRICTED_FIELD));
+  }
+  
 }

--- a/src/main/java/bio/ferlab/clin/utils/MaskingUtils.java
+++ b/src/main/java/bio/ferlab/clin/utils/MaskingUtils.java
@@ -2,7 +2,6 @@ package bio.ferlab.clin.utils;
 
 import bio.ferlab.clin.es.builder.nanuq.AbstractPrescriptionDataBuilder;
 import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
-import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
 
@@ -10,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static bio.ferlab.clin.interceptors.PrescriptionMaskingInterceptor.RESTRICTED_FIELD;
+import static bio.ferlab.clin.interceptors.metatag.PrescriptionMasking.RESTRICTED_FIELD;
 
 public class MaskingUtils {
   

--- a/src/main/java/ca/uhn/fhir/jpa/app/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/app/BaseJpaRestfulServer.java
@@ -97,9 +97,6 @@ public class BaseJpaRestfulServer extends RestfulServer {
     MetaTagInterceptor metaTagInterceptor;
     
     @Autowired
-    PrescriptionMaskingInterceptor prescriptionMaskingInterceptor;
-    
-    @Autowired
     SameRequestInterceptor sameRequestInterceptor;
 
     @Autowired
@@ -424,10 +421,7 @@ public class BaseJpaRestfulServer extends RestfulServer {
         
         if (bioProperties.isTaggingEnabled()) {
             registerInterceptor(metaTagInterceptor);
-            if (bioProperties.isTaggingMasking()) {
-                registerInterceptor(sameRequestInterceptor);
-                registerInterceptor(prescriptionMaskingInterceptor);
-            }
+            registerInterceptor(sameRequestInterceptor);
         }
 
         if (bioProperties.isAuthorizationEnabled()) {

--- a/src/test/java/bio/ferlab/clin/interceptors/PrescriptionMaskingInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/PrescriptionMaskingInterceptorTest.java
@@ -3,6 +3,7 @@ package bio.ferlab.clin.interceptors;
 import bio.ferlab.clin.es.builder.nanuq.AbstractPrescriptionDataBuilder;
 import bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SimplePreResourceShowDetails;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Person;
 import org.hl7.fhir.r4.model.Reference;
@@ -53,8 +54,9 @@ class PrescriptionMaskingInterceptorTest {
     final Person pers = new Person();
     pers.setId("pers1");
     pers.addLink().setTarget(new Reference("Patient/p1"));
+    final SimplePreResourceShowDetails details = new SimplePreResourceShowDetails(pers);
     when(sameRequestInterceptor.get(any())).thenReturn(List.of(sr, p, pers));
-    prescriptionMaskingInterceptor.preShow(null, req1);
+    prescriptionMaskingInterceptor.preShow(details, req1);
     verify(metaTagResourceAccess).getUserTags(req1);
   }
 
@@ -69,10 +71,11 @@ class PrescriptionMaskingInterceptorTest {
     final Person pers = new Person();
     pers.setId("pers1");
     pers.addLink().setTarget(new Reference("Patient/p1"));
+    final SimplePreResourceShowDetails details = new SimplePreResourceShowDetails(pers);
     when(metaTagResourceAccess.getUserTags(any())).thenReturn(List.of("tag1", "tag2"));
     when(metaTagResourceAccess.getResourceTags(any())).thenReturn(List.of("tag1"));
     when(sameRequestInterceptor.get(any())).thenReturn(List.of(sr, p, pers));
-    prescriptionMaskingInterceptor.preShow(null, req1);
+    prescriptionMaskingInterceptor.preShow(details, req1);
     verify(sameRequestInterceptor).get(req1);
     verify(metaTagResourceAccess).getUserTags(req1);
     verify(metaTagResourceAccess).getResourceTags(sr);
@@ -90,10 +93,11 @@ class PrescriptionMaskingInterceptorTest {
     final Person pers = new Person();
     pers.setId("pers1");
     pers.addLink().setTarget(new Reference("Patient/p1"));
+    final SimplePreResourceShowDetails details = new SimplePreResourceShowDetails(pers);
     when(metaTagResourceAccess.getUserTags(any())).thenReturn(List.of("tag1", "tag2"));
     when(metaTagResourceAccess.getResourceTags(any())).thenReturn(List.of("tag3"));
     when(sameRequestInterceptor.get(any())).thenReturn(List.of(sr, p, pers));
-    prescriptionMaskingInterceptor.preShow(null, req1);
+    prescriptionMaskingInterceptor.preShow(details, req1);
     verify(sameRequestInterceptor).get(req1);
     verify(metaTagResourceAccess).getUserTags(req1);
     verify(metaTagResourceAccess).getResourceTags(sr);

--- a/src/test/java/bio/ferlab/clin/interceptors/SameRequestInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/SameRequestInterceptorTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.model.dstu2.resource.Patient;
 import ca.uhn.fhir.model.dstu2.resource.Person;
 import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SimplePreResourceAccessDetails;
 import ca.uhn.fhir.rest.api.server.SimplePreResourceShowDetails;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.junit.jupiter.api.Test;
@@ -16,13 +17,13 @@ class SameRequestInterceptorTest {
   @Test
   void concatResources() {
     final RequestDetails rd1 = Mockito.mock(RequestDetails.class);
-    final SimplePreResourceShowDetails part11 = new SimplePreResourceShowDetails(new ServiceRequest());
-    final SimplePreResourceShowDetails part12 = new SimplePreResourceShowDetails(new Patient());
-    final SimplePreResourceShowDetails part13 = new SimplePreResourceShowDetails(new Person());
+    final SimplePreResourceAccessDetails part11 = new SimplePreResourceAccessDetails(new ServiceRequest());
+    final SimplePreResourceAccessDetails part12 = new SimplePreResourceAccessDetails(new Patient());
+    final SimplePreResourceAccessDetails part13 = new SimplePreResourceAccessDetails(new Person());
 
     final RequestDetails rd2 = Mockito.mock(RequestDetails.class);
-    final SimplePreResourceShowDetails part21 = new SimplePreResourceShowDetails(new ServiceRequest());
-    final SimplePreResourceShowDetails part22 = new SimplePreResourceShowDetails(new Patient());
+    final SimplePreResourceAccessDetails part21 = new SimplePreResourceAccessDetails(new ServiceRequest());
+    final SimplePreResourceAccessDetails part22 = new SimplePreResourceAccessDetails(new Patient());
     
     final SameRequestInterceptor interceptor = new SameRequestInterceptor();
     interceptor.concatResources(part11, rd1);

--- a/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptorTest.java
@@ -121,7 +121,7 @@ class MetaTagInterceptorTest {
     when(metaTagResourceAccess.isResourceWithTags(any(IBaseResource.class))).thenReturn(true);
     when(metaTagResourceVisitor.extractEpCode(any(), any())).thenReturn("ep1");
     when(metaTagResourceVisitor.extractLdmCode(any(), any())).thenReturn("ldm1");
-    when(metaTagResourceAccess.canModifyResource(any(), any())).thenReturn(true);
+    when(metaTagResourceAccess.canSeeResource(any(), any())).thenReturn(true);
     metaTagInterceptor.created(requestDetails, resource);
     verify(metaTagResourceVisitor).extractEpCode(any(), eq(resource));
     verify(metaTagResourceVisitor).extractLdmCode(any(), eq(resource));
@@ -141,7 +141,7 @@ class MetaTagInterceptorTest {
     when(metaTagResourceAccess.isResourceWithTags(any(IBaseResource.class))).thenReturn(true);
     when(metaTagResourceVisitor.extractEpCode(any(), any())).thenReturn("ep1");
     when(metaTagResourceVisitor.extractLdmCode(any(), any())).thenReturn("ldm1");
-    when(metaTagResourceAccess.canModifyResource(any(), any())).thenReturn(true);
+    when(metaTagResourceAccess.canSeeResource(any(), any())).thenReturn(true);
     metaTagInterceptor.updated(requestDetails, null, resource);
     verify(metaTagResourceVisitor).extractEpCode(any(), eq(resource));
     verify(metaTagResourceVisitor).extractLdmCode(any(), eq(resource));
@@ -171,7 +171,7 @@ class MetaTagInterceptorTest {
     when(metaTagResourceAccess.isResourceWithTags(any(IBaseResource.class))).thenReturn(true);
     when(metaTagResourceVisitor.extractEpCode(any(), any())).thenReturn("ep1");
     when(metaTagResourceVisitor.extractLdmCode(any(), any())).thenReturn("ldm1");
-    when(metaTagResourceAccess.canModifyResource(any(), any())).thenReturn(false);
+    when(metaTagResourceAccess.canSeeResource(any(), any())).thenReturn(false);
 
     Exception ex = Assertions.assertThrows(
         ForbiddenOperationException.class,
@@ -181,7 +181,7 @@ class MetaTagInterceptorTest {
     
     verify(metaTagResourceVisitor).extractEpCode(any(), eq(resource));
     verify(metaTagResourceVisitor).extractLdmCode(any(), eq(resource));
-    verify(metaTagResourceAccess).canModifyResource(eq(requestDetails), eq(resource));
+    verify(metaTagResourceAccess).canSeeResource(eq(requestDetails), eq(resource));
 
 
   }

--- a/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagPersonTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagPersonTest.java
@@ -1,0 +1,76 @@
+package bio.ferlab.clin.interceptors.metatag;
+
+import bio.ferlab.clin.es.config.ResourceDaoConfiguration;
+import bio.ferlab.clin.interceptors.SameRequestInterceptor;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Person;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.USER_ALL_TAGS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MetaTagPersonTest {
+  
+  final SameRequestInterceptor sameRequestInterceptor = Mockito.mock(SameRequestInterceptor.class);
+  final IFhirResourceDao<Person> pesonDao = Mockito.mock(IFhirResourceDao.class);
+  final IFhirResourceDao<ServiceRequest> serviceRequestDao = Mockito.mock(IFhirResourceDao.class);
+  final ResourceDaoConfiguration daoConfiguration = new ResourceDaoConfiguration(null, pesonDao, serviceRequestDao, null, null
+      , null, null, null, null, null, null);
+  final MetaTagPerson metaTagPerson = new MetaTagPerson(sameRequestInterceptor, daoConfiguration);
+  
+  @Test
+  void canSeeResource_ep() {
+    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+    final MetaTagResourceAccess access = Mockito.mock(MetaTagResourceAccess.class);
+    when(access.getUserTags(any())).thenReturn(List.of("LDM-1", "EP-1"));
+    final Person person = new Person();
+    assertTrue(metaTagPerson.canSeeResource(access, requestDetails, person));
+  }
+
+  @Test
+  void canSeeResource_system() {
+    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+    final MetaTagResourceAccess access = Mockito.mock(MetaTagResourceAccess.class);
+    when(access.getUserTags(any())).thenReturn(List.of(USER_ALL_TAGS));
+    final Person person = new Person();
+    assertTrue(metaTagPerson.canSeeResource(access, requestDetails, person));
+  }
+
+  @Test
+  void canSeeResource_ldm() {
+    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+    final MetaTagResourceAccess access = Mockito.mock(MetaTagResourceAccess.class);
+    when(access.getUserTags(any())).thenReturn(List.of("LDM-1"));
+    final Person person = new Person();
+    when(sameRequestInterceptor.get(any())).thenReturn(List.of(person));
+    
+    final IBundleProvider personBundle = Mockito.mock(IBundleProvider.class);
+    when(pesonDao.search(any())).thenReturn(personBundle);
+    when(personBundle.isEmpty()).thenReturn(false);
+    when(personBundle.getAllResources()).thenReturn(List.of(new Patient()));
+    
+    final ServiceRequest sr1 = new ServiceRequest();
+    when(access.getResourceTags(any())).thenReturn(List.of("LDM-1"));
+    
+    final IBundleProvider serviceRequestBundle = Mockito.mock(IBundleProvider.class);
+    when(serviceRequestDao.search(any())).thenReturn(serviceRequestBundle);
+    when(serviceRequestBundle.isEmpty()).thenReturn(false);
+    when(serviceRequestBundle.getAllResources()).thenReturn(List.of(sr1));
+    
+    assertTrue(metaTagPerson.canSeeResource(access, requestDetails, person));
+    
+    verify(access).getUserTags(requestDetails);
+    verify(access).getResourceTags(sr1);
+  }
+
+}

--- a/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccessTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccessTest.java
@@ -2,16 +2,11 @@ package bio.ferlab.clin.interceptors.metatag;
 
 import bio.ferlab.clin.exceptions.RptIntrospectionException;
 import bio.ferlab.clin.properties.BioProperties;
-import ca.uhn.fhir.model.dstu2.resource.AuditEvent;
-import ca.uhn.fhir.model.dstu2.resource.Observation;
-import ca.uhn.fhir.model.dstu2.resource.Patient;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import org.hl7.fhir.r4.model.ClinicalImpression;
-import org.hl7.fhir.r4.model.ServiceRequest;
+import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,12 +16,14 @@ import java.util.List;
 
 import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MetaTagResourceAccessTest {
   
   private final BioProperties bioProperties = Mockito.mock(BioProperties.class);
-  private final MetaTagResourceAccess metaTagResourceAccess = new MetaTagResourceAccess(bioProperties);
+  private final MetaTagPerson metaTagPerson = Mockito.mock(MetaTagPerson.class);
+  private final MetaTagResourceAccess metaTagResourceAccess = new MetaTagResourceAccess(bioProperties, metaTagPerson);
   
   @BeforeEach
   void beforeEach() {
@@ -121,28 +118,6 @@ class MetaTagResourceAccessTest {
   }
 
   @Test
-  void canSeeResource_not_GET_nor_POST() {
-    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
-    assertFalse(metaTagResourceAccess.canSeeResource(requestDetails, null));
-  }
-
-  @Test
-  void canSeeResource_POST() {
-    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.POST);
-    String bearer = JWT.create()
-        .withClaim(TOKEN_ATTR_FHIR_ORG_ID, List.of("tag1", "tag2"))
-        .sign(Algorithm.HMAC256("secret"));
-    when(requestDetails.getHeader("Authorization")).thenReturn("Bearer "+ bearer);
-    final ServiceRequest resource = new ServiceRequest();
-    resource.getMeta().addSecurity().setCode("tag3"); // not allowed to see this resource
-    assertFalse(metaTagResourceAccess.canSeeResource(requestDetails, resource));
-    resource.getMeta().addSecurity().setCode("tag1"); // allowed to see this resource
-    assertTrue(metaTagResourceAccess.canSeeResource(requestDetails, resource));
-  }
-
-  @Test
   void canSeeResource_tagging_disabled() {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.GET);
@@ -157,50 +132,13 @@ class MetaTagResourceAccessTest {
     when(bioProperties.isTaggingEnabled()).thenReturn(true);
     assertTrue(metaTagResourceAccess.canSeeResource(requestDetails, new AuditEvent()));
   }
-
+  
   @Test
-  void canModifyResource_POST() {
+  void canSeeResource_Person() {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.POST);
-    String bearer = JWT.create()
-        .withClaim(TOKEN_ATTR_FHIR_ORG_ID, List.of("tag1", "tag2"))
-        .sign(Algorithm.HMAC256("secret"));
-    when(requestDetails.getHeader("Authorization")).thenReturn("Bearer "+ bearer);
-    final ServiceRequest resource = new ServiceRequest();
-    resource.getMeta().addSecurity().setCode("tag3"); // not allowed to see this resource
-    assertFalse(metaTagResourceAccess.canModifyResource(requestDetails, resource));
-    resource.getMeta().addSecurity().setCode("tag1"); // allowed to see this resource
-    assertTrue(metaTagResourceAccess.canModifyResource(requestDetails, resource));
+    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.GET);
+    final Person pers = new Person();
+    metaTagResourceAccess.canSeeResource(requestDetails, pers);
+    verify(metaTagPerson).canSeeResource(metaTagResourceAccess, requestDetails, pers);
   }
-
-  @Test
-  void canModifyResource_PUT() {
-    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.PUT);
-    String bearer = JWT.create()
-        .withClaim(TOKEN_ATTR_FHIR_ORG_ID, List.of("tag1", "tag2"))
-        .sign(Algorithm.HMAC256("secret"));
-    when(requestDetails.getHeader("Authorization")).thenReturn("Bearer "+ bearer);
-    final ServiceRequest resource = new ServiceRequest();
-    resource.getMeta().addSecurity().setCode("tag3"); // not allowed to see this resource
-    assertFalse(metaTagResourceAccess.canModifyResource(requestDetails, resource));
-    resource.getMeta().addSecurity().setCode("tag1"); // allowed to see this resource
-    assertTrue(metaTagResourceAccess.canModifyResource(requestDetails, resource));
-  }
-
-  @Test
-  void canModifyResource_DELETE() {
-    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
-    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.DELETE);
-    String bearer = JWT.create()
-        .withClaim(TOKEN_ATTR_FHIR_ORG_ID, List.of("tag1", "tag2"))
-        .sign(Algorithm.HMAC256("secret"));
-    when(requestDetails.getHeader("Authorization")).thenReturn("Bearer "+ bearer);
-    final ServiceRequest resource = new ServiceRequest();
-    resource.getMeta().addSecurity().setCode("tag3"); // not allowed to see this resource
-    assertFalse(metaTagResourceAccess.canModifyResource(requestDetails, resource));
-    resource.getMeta().addSecurity().setCode("tag1"); // allowed to see this resource
-    assertTrue(metaTagResourceAccess.canModifyResource(requestDetails, resource));
-  }
-
 }

--- a/src/test/java/bio/ferlab/clin/utils/FhirUtilsTest.java
+++ b/src/test/java/bio/ferlab/clin/utils/FhirUtilsTest.java
@@ -1,0 +1,58 @@
+package bio.ferlab.clin.utils;
+
+import org.hl7.fhir.r4.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FhirUtilsTest {
+
+  @Test
+  void formatResource() {
+    final Resource patient = new Patient().setId("foo");
+    assertEquals("Patient/foo", FhirUtils.formatResource(patient));
+  }
+
+  @Test
+  void toReference() {
+    final Resource patient = new Patient().setId("foo");
+    final String expected = new Reference("Patient/foo").getReference();
+    assertEquals(expected, FhirUtils.toReference(patient).getReference());
+  }
+
+  @Test
+  void extractId() {
+    assertNull(FhirUtils.extractId((Reference) null));
+    assertNull(FhirUtils.extractId(new Reference()));
+    assertNull(FhirUtils.extractId(new Reference().setReference("foo")));
+    assertEquals("id", FhirUtils.extractId(new Reference().setReference("TypeResource/id")));
+  }
+
+  @Test
+  void extractId_string() {
+    assertNull(FhirUtils.extractId((String) null));
+    assertNull(FhirUtils.extractId(""));
+    assertNull(FhirUtils.extractId("foo"));
+    assertEquals("100307", FhirUtils.extractId("Patient/100307/_history/2"));
+  }
+
+  @Test
+  void extractAllOfType() {
+    final Bundle innerBundle = new Bundle();
+    innerBundle.addEntry().setResource(new ServiceRequest());
+    List<ServiceRequest> results = FhirUtils.extractAllOfType(List.of(new Person(), new Patient(), new ServiceRequest(), innerBundle), ServiceRequest.class);
+    assertEquals(2, results.size());
+  }
+  
+  @Test
+  void equals() {
+    final Patient p1 = new Patient();
+    p1.setId("1");
+    final Patient p2 = new Patient();
+    p2.setId("1");
+    assertTrue(FhirUtils.equals(p1, p2));
+  }
+
+}

--- a/src/test/java/bio/ferlab/clin/utils/MaskingUtilsTest.java
+++ b/src/test/java/bio/ferlab/clin/utils/MaskingUtilsTest.java
@@ -1,11 +1,13 @@
 package bio.ferlab.clin.utils;
 
-import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Person;
-import org.hl7.fhir.r4.model.Reference;
-import org.hl7.fhir.r4.model.ServiceRequest;
+import bio.ferlab.clin.es.builder.nanuq.AbstractPrescriptionDataBuilder;
+import ca.uhn.fhir.rest.api.server.SimplePreResourceShowDetails;
+import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static bio.ferlab.clin.interceptors.PrescriptionMaskingInterceptor.RESTRICTED_FIELD;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MaskingUtilsTest {
@@ -54,6 +56,64 @@ class MaskingUtilsTest {
 
     assertFalse(MaskingUtils.areLinked(pers1, p2));
     assertFalse(MaskingUtils.areLinked(pers2, p1));
+  }
+  
+  @Test
+  void isAlreadyMasked() {
+    final Person p1 = new Person();
+    p1.setId(RESTRICTED_FIELD);
+    assertTrue(MaskingUtils.isAlreadyMasked(p1));
+    p1.setId("foo");
+    assertFalse(MaskingUtils.isAlreadyMasked(p1));
+  }
+  
+  @Test
+  void isValidPrescriptionRequest_valid() {
+    final ServiceRequest sr = new ServiceRequest();
+    sr.getMeta().addProfile(AbstractPrescriptionDataBuilder.Type.ANALYSIS.value);
+    sr.setSubject(new Reference("Patient/p1"));
+    final Patient p = new Patient();
+    p.setId("p1");
+    final Person pers = new Person();
+    pers.setId("pers1");
+    pers.addLink().setTarget(new Reference("Patient/p1"));
+    assertTrue(MaskingUtils.isValidPrescriptionRequest(List.of(sr, p, pers)));
+  }
+
+  @Test
+  void isValidPrescriptionRequest_not_linked() {
+    final ServiceRequest sr = new ServiceRequest();
+    sr.getMeta().addProfile(AbstractPrescriptionDataBuilder.Type.ANALYSIS.value);
+    sr.setSubject(new Reference("Patient/p1"));
+    final Patient p = new Patient();
+    p.setId("p2");
+    final Person pers = new Person();
+    pers.setId("pers1");
+    pers.addLink().setTarget(new Reference("Patient/p3"));
+    assertFalse(MaskingUtils.isValidPrescriptionRequest(List.of(sr, p, pers)));
+  }
+
+  @Test
+  void isValidPrescriptionRequest_not_analysis() {
+    final ServiceRequest sr = new ServiceRequest();
+    assertFalse(MaskingUtils.isValidPrescriptionRequest(List.of(sr)));
+  }
+  
+  @Test
+  void extractAnalysis() {
+    final ServiceRequest analysis = new ServiceRequest();
+    analysis.getMeta().addProfile(AbstractPrescriptionDataBuilder.Type.ANALYSIS.value);
+    ServiceRequest result = MaskingUtils.extractAnalysis(List.of(new ServiceRequest(), new ServiceRequest(), analysis));
+    assertEquals(analysis, result);
+  }
+  
+  @Test
+  void extractPerson() {
+    final Person person = new Person();
+    final SimplePreResourceShowDetails details = new SimplePreResourceShowDetails(person);
+    assertEquals(person, MaskingUtils.extractPerson(details));
+    
+    assertNull(MaskingUtils.extractPerson(new SimplePreResourceShowDetails(new ServiceRequest())));
   }
   
 }

--- a/src/test/java/bio/ferlab/clin/utils/MaskingUtilsTest.java
+++ b/src/test/java/bio/ferlab/clin/utils/MaskingUtilsTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static bio.ferlab.clin.interceptors.PrescriptionMaskingInterceptor.RESTRICTED_FIELD;
+import static bio.ferlab.clin.interceptors.metatag.PrescriptionMasking.RESTRICTED_FIELD;
 import static org.junit.jupiter.api.Assertions.*;
 
 class MaskingUtilsTest {


### PR DESCRIPTION
Out of a prescription we need to limit the visibility of every queries that will try to access Person as a LDM (Get/GraphQL/Bundle)
_EP are not concerned because they need to know every Person to create prescriptions and don't create duplicated resources._

- [x] Lot of refractoring and units tests
- [x] fix some pom.xml snyk
- [x] Reduce complexity in `MetaTagResourceAccess`
- [x] Change `SameRequestInterceptor` (now contains immutable resources and called before `Consent.canSeeResource`)
- [x] Change `PrescriptionMaskingInterceptor` into `PrescriptionMasking` called from ConsentServiceInterceptor.willSeeResource (mutable)
- [x] Add custom `MetaTagPerson.canSeeResource` (where the real stuff is done ... )