### PR TITLE
feat: CLIN-1468 - replace LDM logic with genetician

### DIFF
--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptor.java
@@ -50,7 +50,7 @@ public class MetaTagInterceptor {
       final List<String> userRoles =  metaTagResourceAccess.getUserRoles(requestDetails);
       final List<String> userTags =  metaTagResourceAccess.getUserTags(requestDetails);
       // ignore filter if no tags or system or Genetician
-      if(!userTags.isEmpty() && !userTags.contains(USER_ALL_TAGS) && userRoles.stream().noneMatch(t -> t.startsWith(USER_ROLE_GENETICIAN))) {
+      if(!userTags.isEmpty() && !userTags.contains(USER_ALL_TAGS) && !userRoles.contains(USER_ROLE_GENETICIAN)) {
         // we use "," separated query param _security because it's a OR relation, at least one should match.
         final String orTags = String.join(",", userTags);
         requestDetails.addParameter("_security", new String[]{orTags});

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptor.java
@@ -15,8 +15,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 
-import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.LDM_TAG_PREFIX;
-import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.USER_ALL_TAGS;
+import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.*;
 
 @Component
 @Interceptor
@@ -48,9 +47,10 @@ public class MetaTagInterceptor {
     if (bioProperties.isTaggingEnabled() && bioProperties.isTaggingQueryParam() 
         && RequestTypeEnum.GET.equals(requestDetails.getRequestType()) 
         && metaTagResourceAccess.isResourceWithTags(requestDetails.getResourceName())) {
+      final List<String> userRoles =  metaTagResourceAccess.getUserRoles(requestDetails);
       final List<String> userTags =  metaTagResourceAccess.getUserTags(requestDetails);
-      // ignore filter if no tags or system or LDM (because not all resources have LDM tags, so we want to see them)
-      if(!userTags.isEmpty() && !userTags.contains(USER_ALL_TAGS) && userTags.stream().noneMatch(t -> t.startsWith(LDM_TAG_PREFIX))) {
+      // ignore filter if no tags or system or Genetician
+      if(!userTags.isEmpty() && !userTags.contains(USER_ALL_TAGS) && userRoles.stream().noneMatch(t -> t.startsWith(USER_ROLE_GENETICIAN))) {
         // we use "," separated query param _security because it's a OR relation, at least one should match.
         final String orTags = String.join(",", userTags);
         requestDetails.addParameter("_security", new String[]{orTags});

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.LDM_TAG_PREFIX;
+import static bio.ferlab.clin.interceptors.metatag.MetaTagResourceAccess.*;
 
 @Component
 @RequiredArgsConstructor
@@ -32,12 +32,13 @@ public class MetaTagPerson {
   
   // custom implementation of canSeeResource for Person
   public boolean canSeeResource(MetaTagResourceAccess metaTagResourceAccess, RequestDetails requestDetails, Person person) {
+    final List<String> userRoles = metaTagResourceAccess.getUserRoles(requestDetails);
     final List<String> userTags = metaTagResourceAccess.getUserTags(requestDetails);
-    if (isOnlyLDM(userTags)) {  // restrict access only for LDMs, EP always see Person
+    if (!userTags.contains(USER_ALL_TAGS) && !isPrescriber(userRoles)) {  // if not system nor prescriber
       final List<IBaseResource> resources = sameRequestInterceptor.get(requestDetails);
       // only if not a prescription (cf PrescriptionMaskingInterceptor)
       if (resources.contains(person) && !MaskingUtils.isValidPrescriptionRequest(resources)) {
-        // Person resources aren't tagged with EP, instead let's find out all related Patients
+        // Person resources aren't tagged with EP/LDM, instead let's find out all related Patients
         final List<Patient> patients = fetchPatients(person);
         final List<ServiceRequest> serviceRequests = fetchServiceRequests(patients);
 
@@ -50,8 +51,8 @@ public class MetaTagPerson {
     return true;
   }
   
-  private boolean isOnlyLDM(List<String> userTags) {
-    return userTags.stream().allMatch(t -> t.startsWith(LDM_TAG_PREFIX));
+  private boolean isPrescriber(List<String> userRoles) {
+    return userRoles.stream().anyMatch(t -> t.startsWith(USER_ROLE_PRESCRIBER));
   }
 
   private List<Patient> fetchPatients(Person person) {

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagPerson.java
@@ -34,7 +34,7 @@ public class MetaTagPerson {
   public boolean canSeeResource(MetaTagResourceAccess metaTagResourceAccess, RequestDetails requestDetails, Person person) {
     final List<String> userRoles = metaTagResourceAccess.getUserRoles(requestDetails);
     final List<String> userTags = metaTagResourceAccess.getUserTags(requestDetails);
-    if (!userTags.contains(USER_ALL_TAGS) && !isPrescriber(userRoles)) {  // if not system nor prescriber
+    if (!userTags.contains(USER_ALL_TAGS) && !userRoles.contains(USER_ROLE_PRESCRIBER)) {  // if not system nor prescriber
       final List<IBaseResource> resources = sameRequestInterceptor.get(requestDetails);
       // only if not a prescription (cf PrescriptionMaskingInterceptor)
       if (resources.contains(person) && !MaskingUtils.isValidPrescriptionRequest(resources)) {
@@ -49,10 +49,6 @@ public class MetaTagPerson {
       }
     }
     return true;
-  }
-  
-  private boolean isPrescriber(List<String> userRoles) {
-    return userRoles.stream().anyMatch(t -> t.startsWith(USER_ROLE_PRESCRIBER));
   }
 
   private List<Patient> fetchPatients(Person person) {

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccess.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccess.java
@@ -55,7 +55,7 @@ public class MetaTagResourceAccess {
         final List<String> userRoles = getUserRoles(requestDetails);
         final List<String> userTags = getUserTags(requestDetails);
         final List<String> resourceTags = getResourceTags(resource);
-        if (userTags.contains(USER_ALL_TAGS) || userRoles.stream().anyMatch(t -> t.startsWith(USER_ROLE_GENETICIAN))) {
+        if (userTags.contains(USER_ALL_TAGS) || userRoles.contains(USER_ROLE_GENETICIAN)) {
           return true;  // can see all
         } else {
           return resourceTags.stream().anyMatch(userTags::contains);  // tagged by EP/LDM

--- a/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccess.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/metatag/MetaTagResourceAccess.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.Claim;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -30,8 +31,11 @@ public class MetaTagResourceAccess {
   // all meta/tags compatible resources, adding one need an implementation in MetaTagResourceVisitor
   public static final List<String> RESOURCES_WITH_TAGS = List.of("ServiceRequest", "Patient", "Observation", "ClinicalImpression");
   public static final String TOKEN_ATTR_FHIR_ORG_ID = "fhir_organization_id";
+  public static final String TOKEN_ATTR_REALM_ACCESS = "realm_access";
+  public static final String USER_ROLE_PRESCRIBER = "clin_prescriber";
+  public static final String USER_ROLE_GENETICIAN = "clin_genetician";
+  public static final String USER_ROLES_CLIN_PREFIX = "clin";
   public static final String USER_ALL_TAGS = "*";
-  public static final String LDM_TAG_PREFIX = "LDM";
   
   private final BioProperties bioProperties;
   private final MetaTagPerson metaTagPerson;
@@ -48,12 +52,13 @@ public class MetaTagResourceAccess {
   public boolean canSeeResource(RequestDetails requestDetails, IBaseResource resource) {
     if (bioProperties.isTaggingEnabled()) {
       if (isResourceWithTags(resource)) {
+        final List<String> userRoles = getUserRoles(requestDetails);
         final List<String> userTags = getUserTags(requestDetails);
         final List<String> resourceTags = getResourceTags(resource);
-        if (userTags.contains(USER_ALL_TAGS) || userTags.stream().anyMatch(t -> t.startsWith(LDM_TAG_PREFIX))) {
+        if (userTags.contains(USER_ALL_TAGS) || userRoles.stream().anyMatch(t -> t.startsWith(USER_ROLE_GENETICIAN))) {
           return true;  // can see all
         } else {
-          return resourceTags.stream().anyMatch(userTags::contains);  // tagged by EP
+          return resourceTags.stream().anyMatch(userTags::contains);  // tagged by EP/LDM
         }
       } else if (resource instanceof Person) {  // Person isn't tagged and has custom access implementation
         return metaTagPerson.canSeeResource(this, requestDetails, (Person) resource);
@@ -64,6 +69,26 @@ public class MetaTagResourceAccess {
   
   public List<String> getResourceTags(IBaseResource resource) {
     return resource.getMeta().getSecurity().stream().map(IBaseCoding::getCode).collect(Collectors.toList());
+  }
+  
+  public List<String> getUserRoles(RequestDetails requestDetails) {
+    final var bearer = requestDetails.getHeader(HttpHeaders.AUTHORIZATION);
+    final var rpt = Helpers.extractAccessTokenFromBearer(bearer);
+    final var jwt = JWT.decode(rpt);
+
+    final List<String> roles = new ArrayList<>();
+
+    roles.addAll(Optional.ofNullable(jwt.getClaim(TOKEN_ATTR_REALM_ACCESS))
+        .map(c -> c.as(RealmAccess.class))
+        .map(c -> c.roles)
+        .orElseThrow(() -> new RptIntrospectionException("missing " + TOKEN_ATTR_REALM_ACCESS)));
+
+    // ignore all roles that aren't clin
+    return roles.stream().filter(r -> r.startsWith(USER_ROLES_CLIN_PREFIX)).collect(Collectors.toList());
+  }
+  
+  public static class RealmAccess {
+    public List<String> roles = new ArrayList();
   }
 
   public List<String> getUserTags(RequestDetails requestDetails) {

--- a/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagInterceptorTest.java
@@ -50,11 +50,12 @@ class MetaTagInterceptorTest {
   }
 
   @Test
-  void addTagParameter_GET_valid_resource_LDM() {
+  void addTagParameter_GET_valid_resource_genetician() {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.GET);
     when(requestDetails.getResourceName()).thenReturn("ValidResource");
     when(metaTagResourceAccess.isResourceWithTags(any(String.class))).thenReturn(true);
+    when(metaTagResourceAccess.getUserRoles(any())).thenReturn(List.of("clin_genetician"));
     when(metaTagResourceAccess.getUserTags(any())).thenReturn(List.of("tag1", "tag2", "LDM-X"));
     metaTagInterceptor.addTagParameter(requestDetails);
     verify(bioProperties).isTaggingEnabled();

--- a/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagPersonTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/metatag/MetaTagPersonTest.java
@@ -29,10 +29,10 @@ class MetaTagPersonTest {
   final MetaTagPerson metaTagPerson = new MetaTagPerson(sameRequestInterceptor, daoConfiguration);
   
   @Test
-  void canSeeResource_ep() {
+  void canSeeResource_not_only_prescriber() {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     final MetaTagResourceAccess access = Mockito.mock(MetaTagResourceAccess.class);
-    when(access.getUserTags(any())).thenReturn(List.of("LDM-1", "EP-1"));
+    when(access.getUserRoles(any())).thenReturn(List.of("clin_prescriber", "clin_genetician"));
     final Person person = new Person();
     assertTrue(metaTagPerson.canSeeResource(access, requestDetails, person));
   }
@@ -47,9 +47,10 @@ class MetaTagPersonTest {
   }
 
   @Test
-  void canSeeResource_ldm() {
+  void canSeeResource_only_genetician() {
     final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
     final MetaTagResourceAccess access = Mockito.mock(MetaTagResourceAccess.class);
+    when(access.getUserRoles(any())).thenReturn(List.of());
     when(access.getUserTags(any())).thenReturn(List.of("LDM-1"));
     final Person person = new Person();
     when(sameRequestInterceptor.get(any())).thenReturn(List.of(person));
@@ -68,7 +69,8 @@ class MetaTagPersonTest {
     when(serviceRequestBundle.getAllResources()).thenReturn(List.of(sr1));
     
     assertTrue(metaTagPerson.canSeeResource(access, requestDetails, person));
-    
+
+    verify(access).getUserRoles(requestDetails);
     verify(access).getUserTags(requestDetails);
     verify(access).getResourceTags(sr1);
   }


### PR DESCRIPTION
Roles have been added to RPT token, better use them than checking LDM tags because a Genetician could be (in the future) in an EP only and no LDM.