### PR TITLE
fix: CLIN-1270 gender update

### DIFF
--- a/src/main/java/bio/ferlab/clin/interceptors/PersonGenderInterceptor.java
+++ b/src/main/java/bio/ferlab/clin/interceptors/PersonGenderInterceptor.java
@@ -1,0 +1,65 @@
+package bio.ferlab.clin.interceptors;
+
+import bio.ferlab.clin.es.config.ResourceDaoConfiguration;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import lombok.RequiredArgsConstructor;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Person;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Interceptor
+@RequiredArgsConstructor
+public class PersonGenderInterceptor {
+
+  private final ResourceDaoConfiguration configuration;
+
+  private boolean isValidRequestAndResource(RequestDetails requestDetails, IBaseResource oldResource, IBaseResource newResource) {
+    return EnumSet.of(RequestTypeEnum.POST, RequestTypeEnum.PUT).contains(requestDetails.getRequestType())
+        && oldResource instanceof Person && newResource instanceof Person;  // instanceof is null-safe
+  }
+
+  /**
+   * Gender information is duplicated, when updating Person we should update all Patients as well (even if not inside the same EP)
+   */
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+  public void updated(RequestDetails requestDetails, IBaseResource oldResource, IBaseResource newResource) {
+    if (isValidRequestAndResource(requestDetails, oldResource, newResource)) {
+      final Person oldPerson = (Person) oldResource;
+      final Person newPerson = (Person) newResource;
+      boolean needUpdate = newPerson.hasGender() && (!oldPerson.hasGender() || (oldPerson.hasGender() && !newPerson.getGender().toCode().equals(oldPerson.getGender().toCode())));
+      if (needUpdate) {
+        final String newGenderCode = newPerson.getGender().toCode();
+        // all linked patients
+        List<String> linkedPatients = extractPatientIds(newPerson);
+        linkedPatients.forEach(id -> updatePatientGender(id, newGenderCode));
+      }
+    }
+  }
+  
+  private List<String> extractPatientIds(Person person) {
+    return person.getLink()
+        .stream().map(Person.PersonLinkComponent::getTarget)
+        .filter(r -> r.getReference().startsWith("Patient/"))
+        .map(r -> r.getReference().replace("Patient/", "")).collect(Collectors.toList());
+  }
+  
+  private void updatePatientGender(String patientId, String newGenderCode) {
+    final Patient patient = configuration.patientDAO.read(new IdType(patientId));
+    if (!patient.hasGender() || !patient.getGender().toCode().equals(newGenderCode)) {
+      patient.setGender(Enumerations.AdministrativeGender.fromCode(newGenderCode));
+      this.configuration.patientDAO.update(patient);
+    }
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/app/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/app/BaseJpaRestfulServer.java
@@ -88,6 +88,9 @@ public class BaseJpaRestfulServer extends RestfulServer {
     ServiceRequestPerformerInterceptor serviceRequestPerformerInterceptor;
     
     @Autowired
+    PersonGenderInterceptor personGenderInterceptor;
+    
+    @Autowired
     ImmutableRamqInterceptor immutableRamqInterceptor;
     
     @Autowired
@@ -418,6 +421,7 @@ public class BaseJpaRestfulServer extends RestfulServer {
         registerInterceptor(serviceRequestPerformerInterceptor);
         registerInterceptor(immutableRamqInterceptor);
         registerInterceptor(immutableMrnInterceptor);
+        registerInterceptor(personGenderInterceptor);
         
         if (bioProperties.isTaggingEnabled()) {
             registerInterceptor(metaTagInterceptor);

--- a/src/test/java/bio/ferlab/clin/interceptors/PersonGenderInterceptorTest.java
+++ b/src/test/java/bio/ferlab/clin/interceptors/PersonGenderInterceptorTest.java
@@ -1,0 +1,71 @@
+package bio.ferlab.clin.interceptors;
+
+import bio.ferlab.clin.es.config.ResourceDaoConfiguration;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.hl7.fhir.r4.model.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PersonGenderInterceptorTest {
+
+  final IFhirResourceDao<Patient> patientDao = Mockito.mock(IFhirResourceDao.class);
+  final ResourceDaoConfiguration configuration = new ResourceDaoConfiguration(patientDao, null,null, null, null
+      , null, null, null, null, null, null);
+  final PersonGenderInterceptor interceptor = new PersonGenderInterceptor(configuration);
+  
+  @Test
+  void should_not_update_null() {
+    shouldUpdate(null, null, false);
+  }
+  
+  @Test
+  void should_not_update_new_gender_null() {
+    shouldUpdate("male", null, false);
+  }
+
+  @Test
+  void should_update_new_gender() {
+    shouldUpdate(null, "male", true);
+  }
+
+  @Test
+  void should_update_replace_gender() {
+    shouldUpdate("male", "female", true);
+  }
+  
+  void shouldUpdate(String oldGenderCode, String newGenderCode, boolean shouldUpdate) {
+    final RequestDetails requestDetails = Mockito.mock(RequestDetails.class);
+    when(requestDetails.getRequestType()).thenReturn(RequestTypeEnum.POST);
+    
+    final Person oldPerson = new Person();
+    oldPerson.setGender(Enumerations.AdministrativeGender.fromCode(oldGenderCode));
+    final Person newPerson = new Person();
+    newPerson.setGender(Enumerations.AdministrativeGender.fromCode(newGenderCode));
+    newPerson.addLink().setTarget(new Reference("Patient/1"));
+    newPerson.addLink().setTarget(new Reference("Patient/2"));
+    
+    final Patient p1 = new Patient();
+    final Patient p2 = new Patient();
+    
+    when(patientDao.read(new IdType(("1")))).thenReturn(p1);
+    when(patientDao.read(new IdType(("2")))).thenReturn(p2);
+    
+    this.interceptor.updated(requestDetails, oldPerson, newPerson);
+    
+    if (shouldUpdate) {
+      verify(patientDao).update(p1);
+      verify(patientDao).update(p2);
+      Assertions.assertEquals(newGenderCode, p1.getGender().toCode());
+      Assertions.assertEquals(newGenderCode, p2.getGender().toCode());
+    }else {
+      verify(patientDao, never()).update(any(Patient.class));
+    }
+  }
+
+}


### PR DESCRIPTION
Gender is a duplicated information between Person/Patient.
When we update Person gender, we should update all linked Patients as well.